### PR TITLE
Fix checkReportLink function in UI tests

### DIFF
--- a/WebApplication/ClientApp/steps_file.js
+++ b/WebApplication/ClientApp/steps_file.js
@@ -293,7 +293,7 @@ module.exports = function() {
     },
     checkReportLink()
     {
-      const workItemLink = '//div[@class="logContainer"]//a[contains(@href,"https://dasprod-store.s3.") and contains(@href,".amazonaws.com/workItem/")]'
+      const workItemLink = '//div[@class="logContainer"]//a[contains(@href,"https://dasprod-store.s3.") and contains(@href,".amazonaws.com/workItem/")]';
       this.waitForVisible(workItemLink, 5);
       this.see('Open log file', workItemLink);
     },


### PR DESCRIPTION
`https://dasprod-store.s3.amazonaws.com/workItem/` changed to `https://dasprod-store.s3.<region>.amazonaws.com/workItem/`
This fix ensures that the new url is matched correctly.