### PR TITLE
Update CreateThumbnailPlugin to use latest Inventor Utils

### DIFF
--- a/AppBundles/CreateThumbnailPlugin/packages.config
+++ b/AppBundles/CreateThumbnailPlugin/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autodesk.Forge.DesignAutomation.Inventor.Utils" version="2.0.0" targetFramework="net48" />
+  <package id="Autodesk.Forge.DesignAutomation.Inventor.Utils" version="2.0.1" targetFramework="net48" />
   <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
Version 2.0.0 doesn't work with .net8 because it uses Thread.Abourt which is deprecated.